### PR TITLE
Fix: aggregate return empty array

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "dev": "SET NODE_ENV=development & nodemon ./bin/www"
+    "dev": "NODE_ENV=development nodemon ./bin/www"
   },
   "repository": {
     "type": "git",

--- a/routes/controller/index.js
+++ b/routes/controller/index.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose");
 const createError = require("http-errors");
 const firebase = require("../../config/firebase");
 
@@ -53,7 +54,7 @@ function postRefresh(req, res, next) {
 
 async function getCondition(req, res, next) {
   try {
-    const creator = req.userId;
+    const creator = mongoose.Types.ObjectId(req.userId);
     const today = new Date();
     const { pastMidnight, pastAMonthAgo } = getPastISOTime(today);
 
@@ -126,11 +127,11 @@ async function getCondition(req, res, next) {
       },
     ];
 
-    const activityData = await Activity.aggregate(dataPipeLine).exec();
-    const mealData = await Meal.aggregate(dataPipeLine).exec();
-    const sleepData = await Sleep.aggregate(dataPipeLine).exec();
-    const albumData = await Album.aggregate(customDataPipeLine).exec();
-    const gridData = await Grid.aggregate(customDataPipeLine).exec();
+    const activityData = await Activity.aggregate(dataPipeLine);
+    const mealData = await Meal.aggregate(dataPipeLine);
+    const sleepData = await Sleep.aggregate(dataPipeLine);
+    const albumData = await Album.aggregate(customDataPipeLine);
+    const gridData = await Grid.aggregate(customDataPipeLine);
 
     res.status(OK);
     res.json({


### PR DESCRIPTION
죄송합니다. 윈도우 환경에서만 쓰이는 dev scripts가 PR에 포함되어있는 걸 뒤늦게 발견하여 수정합니다.
추가로 pipeline정렬 다시 하였습니다!

특이사항
- 현재 aggregate가 빈 배열만 반환하고 있습니다. 
   -> 수정과정에서 creator를 단순히 문자열로 받아서 생긴 에러였습니다. 

```
new Aggregate([{ $match: { _id: '00000000000000000000000a' } }]);
// Do this instead to cast to an ObjectId
new Aggregate([{ $match: { _id: mongoose.Types.ObjectId('00000000000000000000000a') } }]);
```
참조: [Mongoose does not cast pipeline stages. The below will not work unless _id is a string in the database](https://mongoosejs.com/docs/api/aggregate.html#aggregate_Aggregate)