### PR TITLE
Add: Friend detail

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ const customGrid = require("./routes/api/customGrid");
 const customAlbum = require("./routes/api/customAlbum");
 const comment = require("./routes/api/comment");
 const preference = require("./routes/api/preference");
+const friend = require("./routes/api/friend");
 const image = require("./routes/api/image");
 const googleFit = require("./routes/api/googleFit");
 
@@ -32,6 +33,7 @@ app.use(/.*\/customGrid/, customGrid);
 app.use(/.*\/customAlbum/, customAlbum);
 app.use(/.*\/comments/, comment);
 app.use(/.*\/preference/, preference);
+app.use(/.*\/friends/, friend);
 app.use(/.*\/googleFit/, googleFit);
 app.use(/.*\/image/, image);
 

--- a/constants/messages.js
+++ b/constants/messages.js
@@ -14,6 +14,8 @@ const ERROR = {
   INVALID_VALUE: "은(는) 유효하지 않은 값입니다",
   GOOGLE_API_NOT_AVAILABLE: "현재 구글 데이터 이용이 불가능합니다.",
   INVALID_ACTIVITY_TYPE: "유효하지 않은 액티비티 타입입니다",
+  INVALID_FRIEND_ID: "유효하지 않은 친구ID입니다",
+  ALREADY_NOT_FRIEND: "이미 친구가 아닙니다",
 };
 
 module.exports = { ERROR };

--- a/routes/controller/friend.js
+++ b/routes/controller/friend.js
@@ -2,10 +2,13 @@ const createError = require("http-errors");
 const mongoose = require("mongoose");
 
 const User = require("../../models/User");
+const ACCESS_LEVELS = require("../../constants/accessLevels");
 const { ERROR } = require("../../constants/messages");
-const { OK, BAD_REQUEST, NOT_FOUND } = require("../../constants/statusCodes");
+const {
+  OK, NOT_FOUND, UNAUTHORIZED, BAD_REQUEST,
+} = require("../../constants/statusCodes");
 
-async function getFriend(req, res, next) {
+async function getFriends(req, res, next) {
   //
 }
 
@@ -18,11 +21,43 @@ async function patchFriendDetail(req, res, next) {
 }
 
 async function deleteFriendDetail(req, res, next) {
-  //
+  const { creator } = req;
+  const { id: friendId } = req.params;
+
+  try {
+    if (req.accessLevel !== ACCESS_LEVELS.CREATOR) {
+      throw createError(UNAUTHORIZED);
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(friendId)) {
+      throw createError(BAD_REQUEST, ERROR.INVALID_FRIEND_ID);
+    }
+
+    const senderResult = await User.findByIdAndUpdate(creator, {
+      $pull: { friends: mongoose.Types.ObjectId(friendId) },
+    });
+
+    if (!senderResult) {
+      throw createError(NOT_FOUND, ERROR.ALREADY_NOT_FRIEND);
+    }
+
+    const receiverResult = await User.findByIdAndUpdate(friendId, {
+      $pull: { friends: mongoose.Types.ObjectId(creator) },
+    });
+
+    if (!receiverResult) {
+      throw createError(NOT_FOUND, ERROR.ALREADY_NOT_FRIEND);
+    }
+
+    res.status(OK);
+    res.json({ result: "ok" });
+  } catch (err) {
+    next(err);
+  }
 }
 
 module.exports = {
-  getFriend,
+  getFriends,
   sendFriendRequest,
   patchFriendDetail,
   deleteFriendDetail,

--- a/routes/controller/index.js
+++ b/routes/controller/index.js
@@ -137,7 +137,7 @@ async function getProfile(req, res, next) {
 
     const data = recentDataPerModel.reduce((data, dataPerModel) => {
       return data.concat(dataPerModel);
-    }, []);
+    }, []).sort((a, b) => b.date - a.date);
 
     res.status(OK);
     res.json({


### PR DESCRIPTION
- #6 
  - 최근 30일의 게시글을 전부 한 번에 넘겨주도록 하였습니다.  
  - 친구 정보(유저의 프로필)를 얻을 수 있는 경로를 수정하였습니다. 
    - `/friend/:user_id`  =>  `/:creator/profile`
  - aggregate의 addFields를 통해 기본 카테고리는 카테고리 이름을, 커스텀 카테고리는 타입을 추가하는 처리를 한 후 응답을 보냅니다. 예시는 이슈카드에 있습니다. 
  - data는 최근순으로 정렬하였습니다.  
 
- #7 
  - 친구를 삭제하면 친구의 친구목록에서도 요청자를 삭제합니다. 

특이사항
 commit 메시지를 반대로 작성하였습니다. 첫번째 커밋이 #6, 두번째 커밋이 #7 입니다.