### PR TITLE
Fix: handle no image post for meal

### DIFF
--- a/routes/controller/customAlbum.js
+++ b/routes/controller/customAlbum.js
@@ -63,8 +63,6 @@ async function postAlbum(req, res, next) {
       [date, isValidDate],
     ]);
 
-    const url = await getImageUrl(image) || "";
-
     if (invalidValues.length) {
       throw createError(BAD_REQUEST, invalidValues + ERROR.INVALID_VALUE);
     }
@@ -76,8 +74,8 @@ async function postAlbum(req, res, next) {
       category: categoryName,
     };
 
-    if (url) {
-      newAlbum.url = url;
+    if (image) {
+      newAlbum.url = await getImageUrl(image);
     }
 
     const data = await Album.create(newAlbum);

--- a/routes/controller/meal.js
+++ b/routes/controller/meal.js
@@ -60,16 +60,14 @@ async function postMeal(req, res, next) {
       throw createError(BAD_REQUEST, invalidValues + ERROR.INVALID_VALUE);
     }
 
-    const url = await getImageUrl(image) || "";
-
     const newMeal = {
       creator: req.userId,
       date,
       rating: { heartCount, text },
     };
 
-    if (url) {
-      newMeal.url = url;
+    if (image) {
+      newMeal.url = await getImageUrl(image);
     }
 
     const data = await Meal.create(newMeal);


### PR DESCRIPTION
- 업로드 사진이 없을 경우 발생하는 아래 에러에 대응하였습니다.
 ```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
```