### PR TITLE
Add: auth controller test

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -17,6 +17,7 @@ const userSchema = new mongoose.Schema({
   },
   lastAccessDate: {
     type: Date,
+    default: new Date(),
   },
   stroke: {
     type: Number,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     ]
   },
   "jest": {
-    "verbose": true
+    "verbose": true,
+    "restoreMocks": true
   },
   "engines": {
     "node": "14.17.0",

--- a/routes/controller/auth.js
+++ b/routes/controller/auth.js
@@ -70,7 +70,6 @@ async function postLogin(req, res, next) {
       refreshToken,
     });
   } catch (err) {
-    console.log(err);
     next(createError(BAD_REQUEST, ERROR.INVALID_TOKEN));
   }
 }

--- a/routes/controller/auth.js
+++ b/routes/controller/auth.js
@@ -5,7 +5,7 @@ const User = require("../../models/User");
 const firebase = require("../../config/firebase");
 const { ERROR } = require("../../constants/messages");
 const {
-  OK, BAD_REQUEST, UNAUTHORIZED, NOT_FOUND,
+  OK, BAD_REQUEST, NOT_FOUND,
 } = require("../../constants/statusCodes");
 const { generateToken, verifyToken, parseBearer } = require("../helpers/tokens");
 
@@ -48,9 +48,11 @@ async function postLogin(req, res, next) {
       uid, name, picture: profileUrl,
     } = await firebase.auth().verifyIdToken(idToken);
 
-    const { doc: user } = await User.findOrCreate({
-      uid,
-    });
+    let user = await User.findOne({ uid });
+
+    if (!user) {
+      user = await User.create({ uid, profileUrl, name });
+    }
 
     if (user.profileUrl !== profileUrl || user.name !== name) {
       await user.update({
@@ -68,6 +70,7 @@ async function postLogin(req, res, next) {
       refreshToken,
     });
   } catch (err) {
+    console.log(err);
     next(createError(BAD_REQUEST, ERROR.INVALID_TOKEN));
   }
 }

--- a/spec/01-auth.spec.js
+++ b/spec/01-auth.spec.js
@@ -1,0 +1,151 @@
+const request = require("supertest");
+
+const { dbConnect, dbDisconnect } = require("./db");
+const app = require("../app");
+const firebase = require("../config/firebase");
+
+const User = require("../models/User");
+const { mockUser, mockToken } = require("./mockData");
+const { OK } = require("../constants/statusCodes");
+
+beforeAll(async () => await dbConnect());
+afterAll(async () => await dbDisconnect());
+
+describe("POST /login", () => {
+  afterEach(async () => {
+    try {
+      await User.deleteMany();
+    } catch (err) {
+      console.log(`err: ${err} cannot delete mock user`);
+    }
+  });
+
+  it("should get user info from firebase admin", async () => {
+    const spyVerifyToken = jest.fn()
+      .mockReturnValueOnce({
+        uid: mockUser.uid,
+        picture: mockUser.profileUrl,
+        name: mockUser.name,
+      });
+
+    const mockAuth = jest.spyOn(firebase, "auth")
+      .mockReturnValueOnce({ verifyIdToken: spyVerifyToken });
+
+    await request(app)
+      .post("/login")
+      .set("authorization", "Bearer mockFirebaseIdToken")
+      .expect(OK);
+
+    expect(mockAuth).toBeCalledTimes(1);
+    expect(mockAuth).toBeCalledWith();
+    expect(spyVerifyToken).toBeCalledTimes(1);
+    expect(spyVerifyToken).toBeCalledWith("mockFirebaseIdToken");
+  });
+
+  describe("should handle when proper idToken is sended", () => {
+    beforeEach(() => {
+      const spyVerifyToken = jest.fn()
+        .mockReturnValueOnce({
+          uid: mockUser.uid,
+          picture: mockUser.profileUrl,
+          name: mockUser.name,
+        });
+
+      jest.spyOn(firebase, "auth")
+        .mockReturnValueOnce({ verifyIdToken: spyVerifyToken });
+    });
+
+    it("should create user when new user's idToken is sended", async () => {
+      await request(app)
+        .post("/login")
+        .set("authorization", "Bearer mockFirebaseIdToken")
+        .expect(OK)
+        .expect("Content-Type", /json/);
+
+      const createdUser = await User.findOne({ uid: mockUser.uid });
+
+      expect(createdUser).toBeTruthy();
+      expect(createdUser.profileUrl).toBe(mockUser.profileUrl);
+      expect(createdUser.name).toBe(mockUser.name);
+    });
+
+    it("should create respond accessToken when idToken is sended", async () => {
+      const res = await request(app)
+        .post("/login")
+        .set("authorization", "Bearer mockFirebaseIdToken")
+        .expect(OK)
+        .expect("Content-Type", /json/);
+
+      expect(res.body).toBeTruthy();
+      expect(res.body).toHaveProperty("accessToken");
+      expect(res.body).toHaveProperty("refreshToken");
+
+      const { accessToken, refreshToken } = res.body;
+
+      expect(accessToken).toHaveProperty("token");
+      expect(typeof accessToken.token).toBe("string");
+      expect(accessToken).toHaveProperty("exp");
+      expect(typeof accessToken.exp).toBe("number");
+
+      expect(refreshToken).toHaveProperty("token");
+      expect(typeof refreshToken.token).toBe("string");
+      expect(refreshToken).toHaveProperty("exp");
+      expect(typeof refreshToken.exp).toBe("number");
+
+      await request(app)
+        .get("/")
+        .set("authorization", `Bearer ${accessToken.token}`)
+        .expect(OK)
+        .expect("Content-Type", /json/);
+    });
+  });
+
+  it("should update when user's profile has changed", async () => {
+    await User.create({ ...mockUser });
+
+    const spyVerifyToken = jest.fn()
+      .mockReturnValueOnce({
+        uid: mockUser.uid,
+        picture: "updated picture",
+        name: mockUser.name,
+      });
+
+    jest.spyOn(firebase, "auth")
+      .mockReturnValueOnce({ verifyIdToken: spyVerifyToken });
+
+    await request(app)
+      .post("/login")
+      .set("authorization", "Bearer mockFirebaseIdToken")
+      .expect(OK)
+      .expect("Content-Type", /json/);
+
+    const user = await User.findOne({ uid: mockUser.uid });
+
+    expect(user).toBeTruthy();
+    expect(user).toHaveProperty("profileUrl");
+    expect(user.profileUrl).toBe("updated picture");
+  });
+
+  describe("GET /", () => {
+    it("should response user info when accessToken is sended", async () => {
+      await User.create({ ...mockUser });
+
+      const res = await request(app)
+        .get("/")
+        .set("authorization", `Bearer ${mockToken}`)
+        .expect(OK)
+        .expect("Content-Type", /json/);
+
+      expect(res.body).toBeTruthy();
+      expect(res.body).toHaveProperty("userId");
+      expect(res.body).toHaveProperty("customCategories");
+      expect(res.body).toHaveProperty("lastAccessDate");
+
+      const { customCategories, lastAccessDate } = res.body;
+      const date = new Date(lastAccessDate);
+
+      expect(customCategories).toBeInstanceOf(Array);
+      expect(date.getTime()).toBeTruthy();
+    });
+  });
+});

--- a/spec/02-activity.spec.js
+++ b/spec/02-activity.spec.js
@@ -20,7 +20,7 @@ const {
 const { OK } = require("../constants/statusCodes");
 const TIME_OUT = 30000;
 
-beforeAll(() => dbConnect());
+beforeAll(async () => await dbConnect());
 afterAll(async () => await dbDisconnect());
 
 describe("activity controller test", () => {


### PR DESCRIPTION
routes/controller/auth 에 대한 테스트입니다.

- jest 설정에 restoreMocks을 추가하였습니다.
- 테스트 과정에서 발견한 아래 오류를 수정하였습니다.
  - User schema의 lastAccessDate 필드에 기본값이 없어서, 신규 유저가 처음 접속하는 경우 lastAccessDate 필드가 비어있었던 오류
    - 기본값 추가하였습니다.
  - postLogin시 유저 확인에 findOrCreate({ uid })를 사용하여, 신규 유저 추가시 required field인 profileUrl, name이 비어있어 발생하는 오류
    - 먼저 findOne({ uid })로 유저를 검색 후, 없다면 생성하고, profileUrl과 name을 비교해 조건부로 업데이트하도록 변경했습니다.
 
![image](https://user-images.githubusercontent.com/60309558/133709415-7523787e-0623-4dce-ae35-db78758fde6f.png)
