### PR TITLE
Add: comment controller test 

### DIFF
--- a/routes/controller/comment.js
+++ b/routes/controller/comment.js
@@ -90,10 +90,10 @@ async function postComment(req, res, next) {
     });
 
     const commentId = newComment._id;
-    const updated = await RatingModels[modelName].findByIdAndUpdate(ratingId,
-      { $push: { comments: commentId } }).lean();
+    const updatedRating = await RatingModels[modelName]
+      .findByIdAndUpdate(ratingId, { $push: { comments: commentId } }).lean();
 
-    if (!updated) {
+    if (!updatedRating) {
       throw createError(NOT_FOUND);
     }
 

--- a/spec/03-comment.spec.js
+++ b/spec/03-comment.spec.js
@@ -59,7 +59,8 @@ describe("comment controller test /:creatorId/:category/:ratingId/comment", () =
         .set("authorization", `Bearer ${mockToken}`)
         .send({ date: newDate, content: "mock comment" })
         .expect(OK)
-        .expect("Content-Type", /json/);
+        .expect("Content-Type", /json/)
+        .expect({ result: "ok" });
 
       expect(spyCreate).toBeCalledTimes(1);
       expect(spyCreate).toBeCalledWith({
@@ -69,9 +70,6 @@ describe("comment controller test /:creatorId/:category/:ratingId/comment", () =
         date: newDate,
         content: "mock comment",
       });
-
-      expect(res.body).toBeTruthy();
-      expect(res.body.result).toBe("ok");
 
       const updatedActivity = await Activity.findById(mockActivityId);
 
@@ -111,9 +109,6 @@ describe("comment controller test /:creatorId/:category/:ratingId/comment", () =
         .expect(OK)
         .expect("Content-Type", /json/)
         .expect({ result: "ok" });
-
-      expect(res.body).toBeTruthy();
-      expect(res.body.result).toBe("ok");
 
       expect(spyFindById).toBeCalledTimes(1);
       expect(spyFindById).toBeCalledWith(mockCommentId);
@@ -155,9 +150,6 @@ describe("comment controller test /:creatorId/:category/:ratingId/comment", () =
         .expect("Content-Type", /json/)
         .expect({ result: "ok" });
 
-      expect(res.body).toBeTruthy();
-      expect(res.body.result).toBe("ok");
-
       expect(spyFindById).toBeCalledTimes(1);
       expect(spyFindById).toBeCalledWith(createdCommentId.toString());
 
@@ -169,8 +161,6 @@ describe("comment controller test /:creatorId/:category/:ratingId/comment", () =
     });
 
     test("it should not delete comment by request of non-creator", async () => {
-      await User.create(mockFriend);
-
       await request(app)
         .post(`/${mockUserId}/activity/${mockActivityId}/comment`)
         .set("authorization", `Bearer ${mockToken}`)
@@ -190,7 +180,8 @@ describe("comment controller test /:creatorId/:category/:ratingId/comment", () =
 
       const spyFindById = jest.spyOn(Comment, "findById");
 
-      const res = await request(app)
+      await User.create(mockFriend);
+      await request(app)
         .delete(`/${mockUserId}/activity/${mockActivityId}/comment/${createdCommentId}`)
         .set("authorization", `Bearer ${mockFriendToken}`)
         .expect(UNAUTHORIZED);

--- a/spec/03-comment.spec.js
+++ b/spec/03-comment.spec.js
@@ -1,0 +1,208 @@
+const request = require("supertest");
+
+const { dbConnect, dbDisconnect } = require("./db");
+const app = require("../app");
+
+const User = require("../models/User");
+const Activity = require("../models/Activity");
+const Comment = require("../models/Comment");
+const {
+  mockToken,
+  mockFriendToken,
+  mockUserId,
+  mockUser,
+  mockFriend,
+  mockComment,
+  mockCommentId,
+  mockActivityId,
+  mockActivity,
+} = require("./mockData");
+
+const { OK, UNAUTHORIZED } = require("../constants/statusCodes");
+const TIME_OUT = 30000;
+
+beforeAll(async () => await dbConnect());
+afterAll(async () => await dbDisconnect());
+
+describe("comment controller test /:creatorId/:category/:ratingId/comment", () => {
+  jest.setTimeout(TIME_OUT);
+
+  beforeEach(async () => {
+    try {
+      await User.create(mockUser);
+      await Activity.create(mockActivity);
+    } catch (err) {
+      console.log(`err: ${err} cannot set environment for mockComment`);
+    }
+  });
+
+  afterEach(async () => {
+    try {
+      await User.deleteMany();
+      await Activity.deleteMany();
+      await Comment.deleteMany();
+    } catch (err) {
+      console.log(`err: ${err} cannot clean up environment for mockComment`);
+    }
+  });
+
+  describe("POST /", () => {
+    test("it should create comment", async () => {
+      const createdActivity = await Activity.findById(mockActivityId);
+      const spyCreate = jest.spyOn(Comment, "create");
+
+      expect(createdActivity.comments.length).toBe(0);
+
+      const newDate = new Date();
+      const res = await request(app)
+        .post(`/${mockUserId}/activity/${mockActivityId}/comment`)
+        .set("authorization", `Bearer ${mockToken}`)
+        .send({ date: newDate, content: "mock comment" })
+        .expect(OK)
+        .expect("Content-Type", /json/);
+
+      expect(spyCreate).toBeCalledTimes(1);
+      expect(spyCreate).toBeCalledWith({
+        category: "Activity",
+        ratingId: mockActivityId,
+        creator: mockUserId,
+        date: newDate,
+        content: "mock comment",
+      });
+
+      expect(res.body).toBeTruthy();
+      expect(res.body.result).toBe("ok");
+
+      const updatedActivity = await Activity.findById(mockActivityId);
+
+      expect(updatedActivity.comments.length).toBe(1);
+
+      const createdCommentId = updatedActivity.comments[0];
+      const createdComment = await Comment.findById(createdCommentId);
+
+      expect(createdComment).toHaveProperty("category");
+      expect(createdComment).toHaveProperty("ratingId");
+      expect(createdComment).toHaveProperty("creator");
+      expect(createdComment).toHaveProperty("date");
+      expect(createdComment).toHaveProperty("content");
+
+      const commentDate = new Date(createdComment.date);
+
+      expect(commentDate.getTime()).toBeTruthy();
+      expect(commentDate).toEqual(newDate);
+      expect(createdComment.category).toBe("Activity");
+      expect(createdComment.ratingId.equals(updatedActivity._id)).toBeTruthy();
+      expect(createdComment.creator.toString()).toBe(mockUserId);
+      expect(createdComment.content).toBe("mock comment");
+    });
+  });
+
+  describe("PATCH /:commentId", () => {
+    test("it should update comment", async () => {
+      await Comment.create(mockComment);
+
+      const spyFindById = jest.spyOn(Comment, "findById");
+      const newDate = new Date();
+
+      const res = await request(app)
+        .patch(`/${mockUserId}/activity/${mockActivityId}/comment/${mockCommentId}`)
+        .set("authorization", `Bearer ${mockToken}`)
+        .send({ date: newDate, content: "updated" })
+        .expect(OK)
+        .expect("Content-Type", /json/)
+        .expect({ result: "ok" });
+
+      expect(res.body).toBeTruthy();
+      expect(res.body.result).toBe("ok");
+
+      expect(spyFindById).toBeCalledTimes(1);
+      expect(spyFindById).toBeCalledWith(mockCommentId);
+
+      const updatedComment = await Comment.findById(mockCommentId);
+      const commentDate = new Date(updatedComment.date);
+
+      expect(commentDate.getTime()).toBeTruthy();
+      expect(commentDate).toEqual(newDate);
+      expect(updatedComment.content).toBe("updated");
+    });
+  });
+
+  describe("DELETE /:commentId", () => {
+    test("it should delete comment", async () => {
+      await request(app)
+        .post(`/${mockUserId}/activity/${mockActivityId}/comment`)
+        .set("authorization", `Bearer ${mockToken}`)
+        .send({ date: new Date(), content: "mock comment" })
+        .expect(OK)
+        .expect("Content-Type", /json/);
+
+      const activity = await Activity.findById(mockActivityId);
+
+      expect(activity.comments.length).toBe(1);
+
+      const createdCommentId = activity.comments[0];
+      const createdComment = await Comment.findById(createdCommentId);
+
+      expect(createdComment).toHaveProperty("content");
+      expect(createdComment.content).toBe("mock comment");
+
+      const spyFindById = jest.spyOn(Comment, "findById");
+
+      const res = await request(app)
+        .delete(`/${mockUserId}/activity/${mockActivityId}/comment/${createdCommentId}`)
+        .set("authorization", `Bearer ${mockToken}`)
+        .expect(OK)
+        .expect("Content-Type", /json/)
+        .expect({ result: "ok" });
+
+      expect(res.body).toBeTruthy();
+      expect(res.body.result).toBe("ok");
+
+      expect(spyFindById).toBeCalledTimes(1);
+      expect(spyFindById).toBeCalledWith(createdCommentId.toString());
+
+      const updatedActivity = await Activity.findById(mockActivityId);
+      const deletedComment = await Comment.findById(mockCommentId);
+
+      expect(deletedComment).toBeNull();
+      expect(updatedActivity.comments.length).toBe(0);
+    });
+
+    test("it should not delete comment by request of non-creator", async () => {
+      await User.create(mockFriend);
+
+      await request(app)
+        .post(`/${mockUserId}/activity/${mockActivityId}/comment`)
+        .set("authorization", `Bearer ${mockToken}`)
+        .send({ date: new Date(), content: "mock comment" })
+        .expect(OK)
+        .expect("Content-Type", /json/);
+
+      const activity = await Activity.findById(mockActivityId);
+
+      expect(activity.comments.length).toBe(1);
+
+      const createdCommentId = activity.comments[0];
+      const createdComment = await Comment.findById(createdCommentId);
+
+      expect(createdComment).toHaveProperty("content");
+      expect(createdComment.content).toBe("mock comment");
+
+      const spyFindById = jest.spyOn(Comment, "findById");
+
+      const res = await request(app)
+        .delete(`/${mockUserId}/activity/${mockActivityId}/comment/${createdCommentId}`)
+        .set("authorization", `Bearer ${mockFriendToken}`)
+        .expect(UNAUTHORIZED);
+
+      expect(spyFindById).toBeCalledTimes(0);
+
+      const updatedActivity = await Activity.findById(mockActivityId);
+      const targetComment = await Comment.findById(createdCommentId);
+
+      expect(targetComment).toBeTruthy();
+      expect(targetComment.content).toBe("mock comment");
+      expect(updatedActivity.comments.length).toBe(1);
+    });
+  });
+});

--- a/spec/mockData.js
+++ b/spec/mockData.js
@@ -2,8 +2,11 @@ const mongoose = require("mongoose");
 const { generateToken } = require("../routes/helpers/tokens");
 
 const mockUserId = "613c79ac13010b7f24663718";
-const mockActivityId = "613c79ac13010b7f24663711";
+const mockFriendId = "613c79ac13010b7f24663719";
 const mockToken = generateToken(mockUserId).token;
+const mockFriendToken = generateToken(mockFriendId).token;
+const mockActivityId = "613c79ac13010b7f24663711";
+const mockCommentId = "613c79ac13010b7f24663712";
 
 const mockUser = {
   _id: mongoose.Types.ObjectId(mockUserId),
@@ -12,7 +15,15 @@ const mockUser = {
   name: "mock user",
 };
 
+const mockFriend = {
+  _id: mongoose.Types.ObjectId(mockFriendId),
+  uid: "mock friend uid",
+  profileUrl: "mock friend profile",
+  name: "mock friend",
+};
+
 const mockComment = {
+  _id: mongoose.Types.ObjectId(mockCommentId),
   category: "Activity",
   ratingId: mongoose.Types.ObjectId(mockActivityId),
   creator: mongoose.Types.ObjectId(mockUserId),
@@ -38,9 +49,13 @@ const mockStep = {
 
 module.exports = {
   mockToken,
+  mockFriendToken,
   mockUserId,
   mockUser,
+  mockFriendId,
+  mockFriend,
   mockComment,
+  mockCommentId,
   mockActivityId,
   mockActivity,
   mockStep,


### PR DESCRIPTION
routes/controller/comment 에 대한 테스트입니다.

- comment controller에서 해당 rating을 가져오는 부분의 변수명을 수정하였습니다.
- 권한 별 대응을 위해 mockData에 새 유저를 추가하였습니다.

![image](https://user-images.githubusercontent.com/60309558/133743836-4a9ef422-4049-4b75-b515-33ebe8167181.png)
